### PR TITLE
Editorial changes to draft

### DIFF
--- a/draft-ietf-ntp-roughtime.md
+++ b/draft-ietf-ntp-roughtime.md
@@ -26,7 +26,9 @@ author:
     email: "watsonbladd@gmail.com"
  -
     fullname: "Marcus Dansarie"
+    organization: Netnod
     email: marcus@dansarie.se
+    uri: https://orcid.org/0000-0001-9246-0263
 
 normative:
 
@@ -46,20 +48,20 @@ time it is.
 
 Time synchronization is essential to Internet security as many
 security protocols and other applications require synchronization
-{{?RFC738}}. Unfortunately widely deployed protocols such as
+{{?RFC738}}. Unfortunately, widely deployed protocols such as
 the Network Time Protocol (NTP) {{?RFC5905}} lack essential security
 features, and even newer protocols like Network Time Security (NTS)
 {{?RFC8915}} lack mechanisms to ensure that the servers behave
-correctly. Furthermore clients may lack even a basic idea of the time,
-creating bootstrapping problems. Roughtime uses a list of keys and
-servers to resolve this issue.
+correctly. Furthermore, clients may lack even a basic idea of the
+time, creating bootstrapping problems. Roughtime uses a list of keys
+and servers to resolve this issue.
 
 
 # Conventions and Definitions
 
 {::boilerplate bcp14-tagged}
 
-# Protocol Overview
+# Protocol Overview {#protocol-overview}
 
 Roughtime is a protocol for rough time synchronization that enables
 clients to provide cryptographic proof of server malfeasance. It does
@@ -70,29 +72,31 @@ received the client's request. The derived value included in the
 server's response is the root of a Merkle tree which includes the hash
 of the client's nonce as the value of one of its leaf nodes. This
 enables the server to amortize the relatively costly signing operation
-over a number of client requests. Single server mode: At its most
-basic level, Roughtime is a one round protocol in which a completely
-fresh client requests the current time and the server sends a signed
-response. The response includes a timestamp and a radius used to
-indicate the server's certainty about the reported time. For example,
-a radius of 1,000,000 microseconds means the server is absolutely
-confident that the true time is within one second of the reported
-time. The server proves freshness of its response as follows. The
-client's request contains a nonce which the server incorporates into
-its signed response. The client can verify the server's signatures and
-- provided that the nonce has sufficient entropy - this proves that
-the signed response could only have been generated after the nonce.
+over a number of client requests.
+
+Single server mode: At its most basic level, Roughtime is a one round
+protocol in which a completely fresh client requests the current time
+and the server sends a signed response. The response includes a
+timestamp and a radius used to indicate the server's certainty about
+the reported time.
+
+The server proves freshness of its response as follows. The client's
+request contains a nonce which the server incorporates into its signed
+response. The client can verify the server's signatures and - provided
+that the nonce has sufficient entropy - this proves that the signed
+response could only have been generated after the nonce.
 
 # The Guarantee
 
-A Roughtime server guarantees that a response to a query sent at t1,
-received at t2, and with timestamp t3 has been created between the
-transmission of the query and its reception. If t3 is not within that
-interval, a server inconsistency may be detected and used to impeach
-the server. The propagation of such a guarantee and its use of type
-synchronization is discussed in {{integration-into-ntp}}. No delay
-attacker may affect this: they may only expand the interval between
-t1 and t2, or of course stop the measurement in the first place.
+A Roughtime server guarantees that a response to a query sent at
+t<sub>1</sub>, received at t<sub>2</sub>, and with timestamp
+t<sub>3</sub> has been created between t<sub>1</sub> and
+t<sub>2</sub>. If t<sub>3</sub> is not within that interval, a server
+inconsistency may be detected and used to impeach the server. The
+propagation of such a guarantee and its use of type synchronization is
+discussed in {{integration-into-ntp}}. No delay attacker may affect
+this: they may only expand the interval between t<sub>1</sub> and
+t<sub>2</sub>, or of course stop the measurement in the first place.
 
 # Message Format {#message-format}
 
@@ -153,16 +157,16 @@ with the least significant byte first.
 A uint64 is a 64 bit unsigned integer. It is serialized with the least
 significant byte first.
 
-### Tag
+### Tag {#type-tag}
 
 Tags are used to identify values in Roughtime messages. A tag is a
 uint32 but may also be listed in this document as a sequence of up to
 four ASCII characters {{!RFC20}}. ASCII strings shorter than four
 characters can be unambiguously converted to tags by padding them with
 zero bytes. For example, the ASCII string "NONC" would correspond to
-the tag 0x434e4f4e and "PAD" would correspond to 0x00444150. Note that
-when encoded into a message the ASCII values will be in the natural
-bytewise order.
+the tag 0x434e4f4e and "ZZZZ" would correspond to 0x7a7a7a7a. Note
+that when encoded into a message the ASCII values will be in the
+natural bytewise order.
 
 ### Timestamp
 
@@ -187,12 +191,14 @@ than once in a header.
 
 # Protocol Details
 
-As described in Section 3, clients initiate time synchronization by
-sending requests containing a nonce to servers who send signed time
-responses in return. Roughtime packets can be sent between clients and
-servers either as UDP datagrams or via TCP streams. Servers SHOULD
-support the UDP transport mode, while TCP transport is OPTIONAL. A
-Roughtime packet MUST be formatted according to Figure 2 and as
+As described in {{protocol-overview}}, clients initiate time
+synchronization by sending requests containing a nonce to servers who
+send signed time responses in return. Roughtime packets can be sent
+between clients and servers either as UDP datagrams or via TCP
+streams. Servers SHOULD support the UDP transport mode, while TCP
+transport is OPTIONAL.
+
+A Roughtime packet MUST be formatted according to {{figpack}} and as
 described here. The first field is a uint64 with the value
 0x4d49544847554f52 ("ROUGHTIM" in ASCII). The second field is a uint32
 and contains the length of the third field. The third and last field
@@ -218,31 +224,36 @@ contains a Roughtime message as specified in {{message-format}}.
 
 Roughtime request and response packets MUST be transmitted in a single
 datagram when the UDP transport mode is used. Setting the packet's
-don't fragment bit {{!RFC791}} is OPTIONAL in IPv4 networks. Multiple
-requests and responses can be exchanged over an established TCP
-connection. Clients MAY send multiple requests at once and servers MAY
-send responses out of order. The connection SHOULD be closed by the
-client when it has no more requests to send and has received all
+don't fragment bit {{!RFC791}} is OPTIONAL in IPv4 networks.
+
+Multiple requests and responses can be exchanged over an established
+TCP connection. Clients MAY send multiple requests at once and servers
+MAY send responses out of order. The connection SHOULD be closed by
+the client when it has no more requests to send and has received all
 expected responses. Either side SHOULD close the connection in
 response to synchronization, format, implementation-defined timeouts,
-or other errors. All requests and responses MUST contain the VER
-tag. It contains a list of one or more uint32 version numbers. The
-version of Roughtime specified by this memo has version number 1. NOTE
-TO RFC EDITOR: remove this paragraph before publication. For testing
-drafts of this memo, a version number of 0x80000000 plus the draft
-number is used.
+or other errors.
+
+All requests and responses MUST contain the VER tag. It contains a
+list of one or more uint32 version numbers. The version of Roughtime
+specified by this memo has version number 1.
+
+NOTE TO RFC EDITOR: remove this paragraph before publication. For
+testing drafts of this memo, a version number of 0x80000000 plus the
+draft number is used.
 
 ## Requests
 
 A request MUST contain the tags VER and NONC. Tags other than NONC
 and VER SHOULD be ignored by the server. A future version of this
-protocol may mandate additional tags in the message and asign them
-semantic meaning. The size of the request message SHOULD be at least
-1024 bytes when the UDP transport mode is used. To attain this size
-the ZZZZ tag SHOULD be added to the message. Its value SHOULD be all
-zeros. Responding to requests shorter than 1024 bytes is OPTIONAL and
-servers MUST NOT send responses larger than the requests they are
-replying to.
+protocol may mandate additional tags in the message and assign them
+semantic meaning.
+
+The size of the request message SHOULD be at least 1024 bytes when the
+UDP transport mode is used. To attain this size the ZZZZ tag SHOULD be
+added to the message. Its value SHOULD be all zeros. Responding to
+requests shorter than 1024 bytes is OPTIONAL and servers MUST NOT send
+responses larger than the requests they are replying to.
 
 ### VER
 
@@ -268,9 +279,11 @@ guidelines regarding this {{!RFC4086}}.
 In general, a SIG tag value is a 64 byte Ed25519 signature
 {{!RFC8032}} over a concatenation of a signature context ASCII string
 and the entire value of a tag. All context strings MUST include a
-terminating zero byte. The SIG tag in the root of a response MUST be
-a signature over the SREP value using the public key contained in
-CERT. The context string MUST be "RoughTime v1 response signature".
+terminating zero byte.
+
+The SIG tag in the root of a response MUST be a signature over the
+SREP value using the public key contained in CERT. The context string
+MUST be "RoughTime v1 response signature".
 
 ### VER
 
@@ -287,21 +300,24 @@ The NONC tag MUST contain the nonce of the message being responded to.
 
 The PATH tag value MUST be a multiple of 32 bytes long and represent a
 path of 32 byte hash values in the Merkle tree used to generate the
-ROOT value as described in a later section  In the case where a
+ROOT value as described in a {{merkle-tree}}. In the case where a
 response is prepared for a single request and the Merkle tree contains
 only the root node, the size of PATH MUST be zero.
 
-### SERP
+### SREP
 
 The SREP tag contains a time response. Its value MUST be a Roughtime
-message with the tags ROOT, MIDP, and RADI. The server MAY include any
-of the tags DUT1, DTAI, and LEAP in the contents of the SREP tag. The
-ROOT tag MUST contain a 32 byte value of a Merkle tree root as
-described in Section 6.3. The MIDP tag value MUST be timestamp of the
-moment of processing. The RADI tag value MUST be a uint32 representing
-the server's estimate of the accuracy of MIDP in seconds. Servers MUST
-ensure that the true time is within (MIDP-RADI, MIDP+RADI) at the time
-they transmit the response message.
+message with the tags ROOT, MIDP, and RADI.
+
+The ROOT tag MUST contain a 32 byte value of a Merkle tree root as
+described in {{merkle-tree}}.
+
+The MIDP tag value MUST be timestamp of the moment of processing.
+
+The RADI tag value MUST be a uint32 representing the server's estimate
+of the accuracy of MIDP in seconds. Servers MUST ensure that the true
+time is within (MIDP-RADI, MIDP+RADI) at the time they transmit the
+response message.
 
 ### CERT
 
@@ -309,58 +325,74 @@ The CERT tag contains a public-key certificate signed with the
 server's long-term key. Its value is a Roughtime message with the tags
 DELE and SIG, where SIG is a signature over the DELE value. The
 context string used to generate SIG MUST be "RoughTime v1 delegation
-signature--". The DELE tag contains a delegated public-key certificate
-used by the server to sign the SREP tag. Its value is a Roughtime
-message with the tags MINT, MAXT, and PUBK. The purpose of the DELE
-tag is to enable separation of a long-term public key from keys on
-devices exposed to the public Internet. The MINT tag is the minimum
-timestamp for which the key in PUBK is trusted to sign responses. MIDP
-MUST be more than or equal to MINT for a response to be considered
-valid. The MAXT tag is the maximum timestamp for which the key in PUBK
-is trusted to sign responses. MIDP MUST be less than or equal to MAXT
-for a response to be considered valid. The PUBK tag contains a
-temporary 32 byte Ed25519 public key which is used to sign the SREP
-tag.
+signature--".
+
+The DELE tag contains a delegated public-key certificate used by the
+server to sign the SREP tag. Its value is a Roughtime message with the
+tags MINT, MAXT, and PUBK. The purpose of the DELE tag is to enable
+separation of a long-term public key from keys on devices exposed to
+the public Internet.
+
+The MINT tag is the minimum timestamp for which the key in PUBK is
+trusted to sign responses. MIDP MUST be more than or equal to MINT for
+a response to be considered valid.
+
+The MAXT tag is the maximum timestamp for which the key in PUBK is
+trusted to sign responses. MIDP MUST be less than or equal to MAXT for
+a response to be considered valid.
+
+The PUBK tag contains a temporary 32 byte Ed25519 public key which is
+used to sign the SREP tag.
 
 ### INDX
 
 The INDX tag value is a uint32 determining the position of NONC in the
-Merkle tree used to generate the ROOT value as described in later
-section TODO.
+Merkle tree used to generate the ROOT value as described in
+{{merkle-tree}}.
 
-## The Merkel Tree (#tree)
+## The Merkle Tree {#merkle-tree}
 
 A Merkle tree is a binary tree where the value of each non-leaf node
 is a hash value derived from its two children. The root of the tree is
-thus dependent on all leaf nodes. In Roughtime, each leaf node in the
-Merkle tree represents the nonce in one request. Leaf nodes are
-indexed left to right, beginning with zero. The values of all nodes
-are calculated from the leaf nodes and up towards the root node using
-the first 32 bytes of the output of the SHA-512 hash algorithm
-{{!RFC6234}}. For leaf nodes, the byte 0x00 is prepended to the nonce
-before applying the hash function. For all other nodes, the byte 0x01
-is concatenated with first the left and then the right child node
-value before applying the hash function. The value of the Merkle
-tree's root node is included in the ROOT tag of the response. The
-index of a request's nonce node is included in the INDX tag of the
-response. The values of all sibling nodes in the path between a
+thus dependent on all leaf nodes.
+
+In Roughtime, each leaf node in the Merkle tree represents the nonce
+in one request. Leaf nodes are indexed left to right, beginning with
+zero.
+
+The values of all nodes are calculated from the leaf nodes and up
+towards the root node using the first 32 bytes of the output of the
+SHA-512 hash algorithm {{!RFC6234}}. For leaf nodes, the byte 0x00 is
+prepended to the nonce before applying the hash function. For all
+other nodes, the byte 0x01 is concatenated with first the left and
+then the right child node value before applying the hash function.
+
+The value of the Merkle tree's root node is included in the ROOT tag
+of the response.
+
+The index of a request's nonce node is included in the INDX tag of the
+response.
+
+The values of all sibling nodes in the path between a
 request's nonce node and the root node is stored in the PATH tag so
 that the client can reconstruct and validate the value in the ROOT tag
 using its nonce. These values are each 32 bytes and are stored one
 after the other with no additional padding or structure. The order in
 which they are stored is described in the next section.
 
-### Root Value Validity Check Algorithm
+### Root Value Validity Check Algorithm {#check-algorithm}
 
-We describe how to compute the root hash of the Merkel tree from the
-values in the tags PATH, INDX, and NONC. Our algorithm maintains a
-current hash value. The bits of INDX are ordered from least to most
-significant in this algorithm. At initialization hash is set to
-H(0x00 || nonce). If no more entries remain in PATH the current hash
-is the hash of the Merkel tree. All remaining bits of INDX must be
-zero. Otherwise let node be the next 32 bytes in PATH. If the current
-bit in INDX is 0 then hash = H(0x01 || node || hash), else hash =
-H(0x01 || hash || node).
+We describe how to compute the root hash of the Merkle tree from the
+values in the tags PATH, INDX, and NONC. The bits of INDX are ordered
+from least to most significant. `H(x)` denotes the first 32 bytes of
+the SHA-512 hash digest of x and `||` denotes concatenation.
+
+Our algorithm maintains a current hash value. At initialization, hash
+is set to `H(0x00 || nonce)`. If no more entries remain in PATH the
+current hash is the hash of the Merkle tree. All remaining bits of
+INDX MUST be zero at that time. Otherwise, let node be the next 32
+bytes in PATH. If the current bit in INDX is 0 then `hash = H(0x01 ||
+node || hash)`, else `hash = H(0x01 || hash || node)`.
 
 ## Validity of Response
 
@@ -373,7 +405,7 @@ The signature in CERT was made with the long-term key of the server.
 The DELE timestamps and the MIDP value are consistent.
 
 The INDX and PATH values prove NONC was included in the Merkle tree
-with value ROOT using the algorithm in Section 6.3.1.
+with value ROOT using the algorithm in {{check-algorithm}}.
 
 The signature of SREP in SIG validates with the public key in DELE.
 
@@ -413,7 +445,7 @@ signature MAY be invalid for this application.
 
 ## Necessary configuration
 
-To carry out a roughtime measurement a client must be equiped with a
+To carry out a Roughtime measurement a client must be equipped with a
 list of servers, a minimum of three of which are operational, not run
 by the same parties. It must also have a means of reporting to the
 provider of such a list, such as an OS vendor or software vendor, a
@@ -423,9 +455,9 @@ failure report as described below.
 
 The client randomly permutes three servers from the list, and
 sequentially queries them. The first probe uses a NONC that is
-randomly generated. The second query uses H(resp||rand) where rand is
-a random 32 byte value and resp is the entire response to the first
-probe. The third query uses H(resp||rand) for a different 32 byte
+randomly generated. The second query uses `H(resp || rand)` where rand
+is a random 32 byte value and resp is the entire response to the first
+probe. The third query uses `H(resp || rand)` for a different 32 byte
 value.  If the times reported are consistent with the causal ordering,
 and the delay is within a system provided parameter, the measurement
 succeeds. If they are not consistent, there has been malfeasance and
@@ -434,38 +466,55 @@ and make another measurement.
 
 ## Malfeasence reporting
 
-A malfeasance report is a JSON object with keys "nonces" containing an
-array of the rand values as base64 encoded strings and "responses"
-containing the responses as base64 encoded strings. This report is
-cryptographic proof that at least one server generated an incorrect
-response.  Malfeasence reports MAY be transported by any means to the
-relevant vendor or server operator for discussion. A malfeasance
-report is cryptographic proof that the responses arrived in that
-order, and can be used to demonstrate that a server sent the wrong
-time. The venues for sharing such reports and what to do about them
-are outside the scope of this document.
+A malfeasance report is a JSON {{!RFC8259}} object with keys "nonces"
+containing an array of the rand values as base64 {{!RFC4648}} encoded
+strings and "responses" containing an array of the responses as base64
+encoded strings.
+
+Malfeasence reports MAY be transported by any means to the relevant
+vendor or server operator for discussion. A malfeasance report is
+cryptographic proof that the responses arrived in that order, and can
+be used to demonstrate that at least one server sent the wrong time.
+The venues for sharing such reports and what to do about them are
+outside the scope of this document.
 
 # Security Considerations
 
 Since the only supported signature scheme, Ed25519, is not quantum
 resistant, the Roughtime version described in this memo will not
-survive the advent of quantum computers.  Maintaining a list of
-trusted servers and adjudicating violations of the rules by servers is
-not discussed in this document and is essential for
-security. Roughtime clients MUST regularly update their view of which
-servers are trustworthy in order to benefit from the detection of
-misbehavior. Validating timestamps made on different dates requires
-knowledge of leap seconds in order to calculate time intervals
-correctly. Servers carry out a significant amount of computation in
-response to clients, and thus may experience vulnerability to denial
-of service attacks. This protocol does not provide any
-confidentiality. Given the nature of timestamps such impact is
-minor. The compromise of a PUBK's private key, even past MAXT, is a
-problem as the private key can be used to sign invalid times that are
-in the range MINT to MAXT, and thus violate the good behavior
-guarantee of the server. Servers MUST NOT send response packets larger
-than the request packets sent by clients, in order to prevent
-amplification attacks.
+survive the advent of quantum computers.
+
+Maintaining a list of trusted servers and adjudicating violations of
+the rules by servers is not discussed in this document and is
+essential for security. Roughtime clients MUST regularly update their
+view of which servers are trustworthy in order to benefit from the
+detection of misbehavior.
+
+Validating timestamps made on different dates requires knowledge of
+leap seconds in order to calculate time intervals correctly.
+
+Servers carry out a significant amount of computation in response to
+clients, and thus may experience vulnerability to denial of service
+attacks.
+
+This protocol does not provide any confidentiality. Given the nature
+of timestamps such impact is minor.
+
+The compromise of a PUBK's private key, even past MAXT, is a problem
+as the private key can be used to sign invalid times that are in the
+range MINT to MAXT, and thus violate the good behavior guarantee of
+the server.
+
+Servers MUST NOT send response packets larger than the request packets
+sent by clients, in order to prevent amplification attacks.
+
+# Privacy Considerations
+
+This protocol is designed to obscure all client identifiers. Servers
+necessarily have persistent long-term identities essential to
+enforcing correct behavior. Generating nonces in a nonrandom manner
+can cause leaks of private data or enable tracking of clients as they
+move between networks.
 
 # IANA Considerations
 
@@ -493,13 +542,13 @@ Name and Transport Protocol Port Number Registry:
  IANA is requested to create a new registry entitled "Roughtime
  Version Registry".  Entries shall have the following fields:
 
-      Version ID (REQUIRED): a 32-bit unsigned integer
+Version ID (REQUIRED): a 32-bit unsigned integer
 
-      Version name (REQUIRED): A short text string naming the version
-      being identified.
+Version name (REQUIRED): A short text string naming the version being
+identified.
 
-      Reference (REQUIRED): A reference to a relevant specification
-      document.
+Reference (REQUIRED): A reference to a relevant specification
+document.
 
 The policy for allocation of new entries SHOULD be: IETF Review.
 
@@ -518,13 +567,13 @@ The initial contents of this registry shall be as follows:
 IANA is requested to create a new registry entitled "Roughtime Tag
 Registry".  Entries SHALL have the following fields:
 
-	      Tag (REQUIRED): A 32-bit unsigned integer in hexadecimal format.
+Tag (REQUIRED): A 32-bit unsigned integer in hexadecimal format.
 
-	      ASCII Representation (OPTIONAL): The ASCII representation of the
-	      tag in accordance with Section 5.1.4 of this memo, if applicable.
+ASCII Representation (OPTIONAL): The ASCII representation of the tag
+in accordance with {{type-tag}} of this memo, if applicable.
 
-	      Reference (REQUIRED): A reference to a relevant specification
-	      document.
+Reference (REQUIRED): A reference to a relevant specification
+document.
 
 The policy for allocation of new entries in this registry SHOULD be:
 Specification Required.
@@ -550,14 +599,6 @@ The initial contents of this registry SHALL be as follows:
 | 0x5458414d | MAXT                 | [[this memo]] |
 | 0x58444e49 | INDX                 | [[this memo]] |
 
-
-# Privacy Considerations
-
-This protocol is designed to obscure all client identifiers. Servers
-necessarily have persistent long-term identities essential to
-enforcing correct behavior. Generating nonces in a nonrandom manner
-can cause leaks of private data or enable tracking of clients as they
-move between networks.
 
 --- back
 

--- a/draft-ietf-ntp-roughtime.md
+++ b/draft-ietf-ntp-roughtime.md
@@ -164,7 +164,7 @@ uint32 but may also be listed in this document as a sequence of up to
 four ASCII characters {{!RFC20}}. ASCII strings shorter than four
 characters can be unambiguously converted to tags by padding them with
 zero bytes. For example, the ASCII string "NONC" would correspond to
-the tag 0x434e4f4e and "ZZZZ" would correspond to 0x7a7a7a7a. Note
+the tag 0x434e4f4e and "ZZZZ" would correspond to 0x5a5a5a5a. Note
 that when encoded into a message the ASCII values will be in the
 natural bytewise order.
 


### PR DESCRIPTION
This fixes a number of minor issues with the draft, including many mentioned in aanchal4/draft-roughtime#45. None of them should be controversial.

* Update author name and organzation.
* Fix misspellings and missing commas.
* Many sections were mushed together into a single paragraph when the draft was converted to Markdown. They are now split up into separate paragraphs again.
* Fix links to sections and figures.
* Update description of radius in protocol overview to be consistent with new radius format.
* Proper variable index subscript in "The Guarantee".
* Replace PAD example with ZZZZ example.
* Some clarifications in "Root Value Validity Check Algorithm"
* Fix paragraphs in "IANA Considerations" that were cut off in the pdf version.
* Move "Privacy Considerations" to come after "Security Considerations".
* Reference RFCs for JSON and base64.